### PR TITLE
Missed days reminders shouldn't be lost

### DIFF
--- a/cmd/testdata/missedday/2000-01-01.md
+++ b/cmd/testdata/missedday/2000-01-01.md
@@ -1,0 +1,5 @@
+# Andrew Allen - 2000-01-01
+
+Today I did stuff and things.
+
+Tomorrow: I will finish the thing I forgot to do.

--- a/cmd/testdata/missedday/2000-01-03.out
+++ b/cmd/testdata/missedday/2000-01-03.out
@@ -1,0 +1,5 @@
+# Andrew Allen - 2000-01-03
+
+Missed Reminders:
+From 2000-01-01: I will finish the thing I forgot to do.
+


### PR DESCRIPTION
If no log was generated on that day make a new section called "missed
reminders".

Fixes #5 